### PR TITLE
Copy base config properties to new config object instead of inheriting

### DIFF
--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -4,7 +4,7 @@
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const baseConfig = require('./webpack.config.base');
-const config = Object.create(baseConfig);
+const config = Object.assign({}, baseConfig);
 
 config.debug = true;
 

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -5,7 +5,7 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const baseConfig = require('./webpack.config.base');
-const config = Object.create(baseConfig);
+const config = Object.assign({}, baseConfig);
 
 config.devtool = 'source-map';
 


### PR DESCRIPTION
I ran into issues with other tools that try to load webpack configs through their own webpack loaders.

`Object.create` assigns the base webpack config as a parent of the child config object. Instead, using `Object.assign` to actually copy the values from the parent to the child. That allows the properties to be iterable so that other libraries can see the config properties.
